### PR TITLE
ユーザーのポイントの管理

### DIFF
--- a/src/main/scala/sample/AccountManager.scala
+++ b/src/main/scala/sample/AccountManager.scala
@@ -10,11 +10,11 @@ object AccountManager {
 
   def name = "accountManager"
 
-  case class User(name: String, age: Int)
+  case class User(name: String, points: Int)
 
   case class Users(users: Vector[User])
 
-  case class CreateUser(name: String, age: Int)
+  case class CreateUser(name: String, points: Int)
 
   case class GetUser(name: String)
 
@@ -41,10 +41,10 @@ class AccountManager extends Actor {
     case GetUser(name) => sender() ! users.get(name)
     case GetUsers =>
       sender() ! Users(users.values.toVector)
-    case CreateUser(name, age) =>
+    case CreateUser(name, points) =>
       if (users.contains(name)) sender() ! UserExists
       else {
-        val user = User(name, age)
+        val user = User(name, points)
         users = users + (name -> user)
         sender() ! UserCreated(user)
       }

--- a/src/main/scala/sample/AccountManager.scala
+++ b/src/main/scala/sample/AccountManager.scala
@@ -1,12 +1,14 @@
 package sample
 
-import akka.actor.{Actor, Props}
+import scala.concurrent.Future
+import akka.actor.{Actor, ActorRef, Props}
+import akka.util.Timeout
 
 /**
   * AccountManagerのPropsの定義、メッセージの定義
   */
 object AccountManager {
-  def props() = Props[AccountManager]
+  def props(implicit timeout: Timeout) = Props(new AccountManager())
 
   def name = "accountManager"
 
@@ -31,7 +33,7 @@ object AccountManager {
 /**
   * Accountの管理を行うActor
   */
-class AccountManager extends Actor {
+class AccountManager(implicit timeout: Timeout) extends Actor {
 
   import AccountManager._
 

--- a/src/main/scala/sample/AccountManager.scala
+++ b/src/main/scala/sample/AccountManager.scala
@@ -36,19 +36,46 @@ object AccountManager {
 class AccountManager(implicit timeout: Timeout) extends Actor {
 
   import AccountManager._
+  import context._
 
-  var users: Map[String, User] = Map.empty[String, User]
+  def createUserDetail(name: String) =
+    context.actorOf(UserDetail.props(name), name)
 
   override def receive: Receive = {
-    case GetUser(name) => sender() ! users.get(name)
+    case GetUser(name) =>
+      def notFound(): Unit = sender() ! None
+
+      /**
+        * about forward
+        * parent: Actor
+        * child: Actor
+        * grandchild: Actor
+        * 1. parent send child 'messageA'
+        * 2. child receive 'messageA'
+        * 3. child forward grandchild 'messageB'
+        * 4. in grandchild, sender() is parent
+        */
+      def forwardGetMessage(child: ActorRef): Unit = child forward UserDetail.GetUser
+
+      context.child(name).fold(notFound())(forwardGetMessage)
+
     case GetUsers =>
-      sender() ! Users(users.values.toVector)
-    case CreateUser(name, points) =>
-      if (users.contains(name)) sender() ! UserExists
-      else {
-        val user = User(name, points)
-        users = users + (name -> user)
-        sender() ! UserCreated(user)
+      import akka.pattern.ask
+      import akka.pattern.pipe
+      def getUsers = context.children.map { child =>
+        self.ask(GetUser(child.path.name)).mapTo[Option[User]]
       }
+
+      val f = Future.sequence(getUsers).map(_.flatten).map(l => Users(l.toVector))
+      pipe(f) to sender()
+
+    case CreateUser(name, points) =>
+      def create(): Unit = {
+        val actor = createUserDetail(name)
+        actor ! UserDetail.GetPoints(points)
+        sender() ! UserCreated(User(name, points))
+      }
+
+      context.child(name).fold(create())(_ => sender() ! UserExists)
   }
 }

--- a/src/main/scala/sample/Api.scala
+++ b/src/main/scala/sample/Api.scala
@@ -36,9 +36,9 @@ trait MyJsonProtocol extends DefaultJsonProtocol {
 class Api(system: ActorSystem) extends ApiRoutes {
   implicit def executionContext = system.dispatcher
 
-  override def createAccountManager(): ActorRef = system.actorOf(AccountManager.props, AccountManager.name)
-
   override implicit def requestTimeout: Timeout = Timeout(100 milliseconds)
+
+  override def createAccountManager(): ActorRef = system.actorOf(AccountManager.props, AccountManager.name)
 }
 
 /**

--- a/src/main/scala/sample/Api.scala
+++ b/src/main/scala/sample/Api.scala
@@ -22,7 +22,7 @@ trait MyJsonProtocol extends DefaultJsonProtocol {
 
   implicit val userFormat = jsonFormat2(User)
   implicit val usersFormat = jsonFormat1(Users)
-  implicit val userAgeFormat = jsonFormat1(UserAge)
+  implicit val userAgeFormat = jsonFormat1(UserPoints)
   implicit val errorFormat = jsonFormat1(Error)
 }
 
@@ -91,8 +91,8 @@ trait ApiRoutes extends MyJsonProtocol with AccountManagerApi {
         } ~
           post {
             //entity(as[T]) { t: T => ...  となる
-            entity(as[UserAge]) { ua =>
-              onSuccess(createUser(name, ua.age)) {
+            entity(as[UserPoints]) { ua =>
+              onSuccess(createUser(name, ua.points)) {
                 case AccountManager.UserCreated(user) =>
                   complete(Created, user)
                 case AccountManager.UserExists =>
@@ -121,8 +121,8 @@ trait AccountManagerApi {
 
   lazy val accountManager = createAccountManager()
 
-  def createUser(name: String, age: Int) =
-    accountManager.ask(CreateUser(name, age)).mapTo[Response]
+  def createUser(name: String, points: Int) =
+    accountManager.ask(CreateUser(name, points)).mapTo[Response]
 
   def getUser(name: String) =
     accountManager.ask(GetUser(name)).mapTo[Option[User]]
@@ -131,6 +131,6 @@ trait AccountManagerApi {
     accountManager.ask(GetUsers).mapTo[Users]
 }
 
-case class UserAge(age: Int)
+case class UserPoints(points: Int)
 
 case class Error(message: String)

--- a/src/main/scala/sample/UserDetail.scala
+++ b/src/main/scala/sample/UserDetail.scala
@@ -1,0 +1,26 @@
+package sample
+
+import akka.actor.{Actor, Props}
+
+object UserDetail {
+  def props(name: String) = Props(new UserDetail(name))
+
+  case object GetUser
+
+  case class GetPoints(points: Int)
+
+  case class UsePoint(points: Int)
+
+}
+
+class UserDetail(name: String) extends Actor {
+
+  import UserDetail._
+
+  var points: Int = 0
+
+  override def receive: Receive = {
+    case GetPoints(gotPoints) => points = points + gotPoints
+    case GetUser => sender() ! Some(AccountManager.User(name, points))
+  }
+}

--- a/src/test/scala/sample/AccountManagerSpec.scala
+++ b/src/test/scala/sample/AccountManagerSpec.scala
@@ -2,7 +2,9 @@ package sample
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import akka.util.Timeout
 import org.scalatest.{MustMatchers, WordSpecLike}
+import scala.concurrent.duration._
 
 class AccountManagerSpec extends TestKit(ActorSystem("AccountManager"))
   with WordSpecLike
@@ -10,6 +12,8 @@ class AccountManagerSpec extends TestKit(ActorSystem("AccountManager"))
   with StopSystemAfterAll {
 
   import AccountManager._
+
+  implicit val requestTimeout: Timeout = Timeout(100 milliseconds)
 
   "AccountManager" must {
     "return saved user when receive CreateUser" in {

--- a/src/test/scala/sample/UserDetailSpec.scala
+++ b/src/test/scala/sample/UserDetailSpec.scala
@@ -1,0 +1,38 @@
+package sample
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.scalatest.{MustMatchers, WordSpecLike}
+import sample.UserDetail.{GetPoints, GetUser}
+
+class UserDetailSpec extends TestKit(ActorSystem("UserDetail"))
+  with WordSpecLike
+  with MustMatchers
+  with StopSystemAfterAll {
+
+  "UserDetail" must {
+    "return User of points = 0 when don't receiveGetPoints" in {
+      val name = "name1"
+      val uerDetail = system.actorOf(UserDetail.props(name), name)
+      uerDetail.tell(GetUser, testActor)
+      expectMsg(Some(AccountManager.User(name, 0)))
+    }
+
+    "return User that have received points when receive GetPoints" in {
+      val name = "name2"
+      val uerDetail = system.actorOf(UserDetail.props(name), name)
+      uerDetail ! GetPoints(10)
+      uerDetail.tell(GetUser, testActor)
+      expectMsg(Some(AccountManager.User(name, 10)))
+    }
+
+    "overflow points when receive two GetPoints over Int.MaxValue" in {
+      val name = "name3"
+      val uerDetail = system.actorOf(UserDetail.props(name), name)
+      uerDetail ! GetPoints(Int.MaxValue)
+      uerDetail ! GetPoints(1)
+      uerDetail.tell(GetUser, testActor)
+      expectMsg(Some(AccountManager.User(name, Int.MinValue)))
+    }
+  }
+}


### PR DESCRIPTION
ユーザーは名前とポイントを保持するように変更
それに伴って、AccountManager アクターがユーザーのMapを保持するのではなく、
UserDetail アクターを生成し、それに管理させるように変更